### PR TITLE
Thread Automation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "*"
 
 jobs:
   build:
@@ -20,9 +21,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set Docker Tags
+        id: vars
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          BRANCH_NAME=${BRANCH_NAME//\//-}
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            echo "TAG=latest" >> $GITHUB_ENV
+          else
+            echo "TAG=$BRANCH_NAME" >> $GITHUB_ENV
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: ghcr.io/xsaoul/sah_support:latest
+          tags: ghcr.io/xsaoul/sah_support:${{ env.TAG }}

--- a/commands/solved.js
+++ b/commands/solved.js
@@ -11,9 +11,18 @@ module.exports = new CommandBuilder()
     const tags = forum.availableTags;
     const currentTags = channel.appliedTags;
     const solvedTag = tags.find(tag => tag.name.toLowerCase() === 'solved');
-    if (currentTags.includes(solvedTag.id)) return ctx.interaction.reply({ content: 'This post is already marked as solved.', ephemeral: true });
-    const newTags = [solvedTag.id];
-    channel.setAppliedTags(newTags);
+    if (!solvedTag) {
+      ctx.interaction.reply({
+        content: "Oops, something went wrong! Our team has been notified, and we'll work on fixing it. Please try again later.",
+        ephemeral: true,
+      });
+      console.log('No solved tag found, does it exist?');
+      return;
+    }
+    if (!currentTags.includes(solvedTag.id)) {
+      const newTags = [solvedTag.id];
+      channel.setAppliedTags(newTags);
+    }
     ctx.interaction.reply({ content: `This post has been marked as solved.\n-# Post closed <t:${Date.now().toString().slice(0, -3)}:R>.` });
     channel.setArchived(true);
   });

--- a/commands/solved.js
+++ b/commands/solved.js
@@ -6,6 +6,8 @@ module.exports = new CommandBuilder()
   .setCallback(ctx => {
     const channel = ctx.channel;
     const forum = channel.parent;
+    if (forum.parent?.name.toLowerCase() !== 'support' || channel.type !== 11)
+      return ctx.interaction.reply({ content: 'This command can only be used in a support thread.', ephemeral: true });
     const tags = forum.availableTags;
     const currentTags = channel.appliedTags;
     const solvedTag = tags.find(tag => tag.name.toLowerCase() === 'solved');

--- a/events/idle_thread/createTimer.js
+++ b/events/idle_thread/createTimer.js
@@ -8,7 +8,6 @@ module.exports = new EventBuilder()
     const opId = msg.channel.ownerId;
     const threadId = msg.channel.id;
     const parent = msg.channel.parent;
-    if (opId !== '439601142528344065') return;
     if (opId !== msg.author.id) return;
     if (parent.parent?.name.toLowerCase() !== 'support' || msg.channel.type !== 11) return;
     const [result] = await db.execute(

--- a/events/idle_thread/createTimer.js
+++ b/events/idle_thread/createTimer.js
@@ -8,6 +8,7 @@ module.exports = new EventBuilder()
     const opId = msg.channel.ownerId;
     const threadId = msg.channel.id;
     const parent = msg.channel.parent;
+    if (opId !== '439601142528344065') return;
     if (opId !== msg.author.id) return;
     if (parent.parent?.name.toLowerCase() !== 'support' || msg.channel.type !== 11) return;
     await db.execute(

--- a/events/idle_thread/createTimer.js
+++ b/events/idle_thread/createTimer.js
@@ -11,7 +11,7 @@ module.exports = new EventBuilder()
     if (opId !== '439601142528344065') return;
     if (opId !== msg.author.id) return;
     if (parent.parent?.name.toLowerCase() !== 'support' || msg.channel.type !== 11) return;
-    await db.execute(
+    const [result] = await db.execute(
       `
       INSERT INTO thread_timers (thread_id, op_id, last_posted, reminder_sent)
       VALUES (?, ?, NOW(), FALSE)
@@ -19,4 +19,5 @@ module.exports = new EventBuilder()
       `,
       [threadId, opId]
     );
+    if (result.affectedRows === 1) console.log(`Thread ${threadId} for OP ${opId} has been created.`);
   });

--- a/events/idle_thread/createTimer.js
+++ b/events/idle_thread/createTimer.js
@@ -1,0 +1,21 @@
+const { EventBuilder, Events } = require('shardclient');
+const db = require('../../mariadb');
+module.exports = new EventBuilder()
+  .setName('idleTimer')
+  .setTrigger(Events.MessageCreate)
+  .setCallback(async (client, msg) => {
+    if (msg.author.bot) return;
+    const opId = msg.channel.ownerId;
+    const threadId = msg.channel.id;
+    const parent = msg.channel.parent;
+    if (opId !== msg.author.id) return;
+    if (parent.parent?.name.toLowerCase() !== 'support' || msg.channel.type !== 11) return;
+    await db.execute(
+      `
+      INSERT INTO thread_timers (thread_id, op_id, last_posted, reminder_sent)
+      VALUES (?, ?, NOW(), FALSE)
+      ON DUPLICATE KEY UPDATE last_posted = NOW(), reminder_sent = FALSE, close_scheduled_time = NULL
+      `,
+      [threadId, opId]
+    );
+  });

--- a/events/idle_thread/startIntervals.js
+++ b/events/idle_thread/startIntervals.js
@@ -1,0 +1,17 @@
+const { EventBuilder, Events } = require('shardclient');
+const checkIdleThreads = require('../../tasks/idleCheck');
+const checkClosingThreads = require('../../tasks/closeThreads');
+module.exports = new EventBuilder()
+  .setName('startIntervals')
+  .setTrigger(Events.ClientReady)
+  .setOnce(true)
+  .setCallback(client => {
+    setInterval(
+      () => {
+        console.log('Checking idle and closing threads...');
+        checkIdleThreads(client);
+        checkClosingThreads(client);
+      },
+      60 * 60 * 1000
+    );
+  });

--- a/events/idle_thread/startIntervals.js
+++ b/events/idle_thread/startIntervals.js
@@ -6,12 +6,9 @@ module.exports = new EventBuilder()
   .setTrigger(Events.ClientReady)
   .setOnce(true)
   .setCallback(client => {
-    setInterval(
-      () => {
-        console.log('Checking idle and closing threads...');
-        checkIdleThreads(client);
-        checkClosingThreads(client);
-      },
-      60 * 60 * 1000
-    );
+    setInterval(() => {
+      console.log('Checking idle and closing threads...');
+      checkIdleThreads(client);
+      checkClosingThreads(client);
+    }, 60 * 1000);
   });

--- a/events/idle_thread/startIntervals.js
+++ b/events/idle_thread/startIntervals.js
@@ -1,6 +1,6 @@
 const { EventBuilder, Events } = require('shardclient');
-const checkIdleThreads = require('../../tasks/idleCheck');
-const checkClosingThreads = require('../../tasks/closeCheck');
+const { checkIdleThreads } = require('../../tasks/idleCheck');
+const { checkClosingThreads } = require('../../tasks/closeCheck');
 module.exports = new EventBuilder()
   .setName('startIntervals')
   .setTrigger(Events.ClientReady)

--- a/events/idle_thread/startIntervals.js
+++ b/events/idle_thread/startIntervals.js
@@ -6,9 +6,11 @@ module.exports = new EventBuilder()
   .setTrigger(Events.ClientReady)
   .setOnce(true)
   .setCallback(client => {
-    setInterval(() => {
-      console.log('Checking idle and closing threads...');
-      checkIdleThreads(client);
-      checkClosingThreads(client);
-    }, 60 * 1000);
+    setInterval(
+      () => {
+        checkIdleThreads(client);
+        checkClosingThreads(client);
+      },
+      60 * 60 * 1000
+    );
   });

--- a/events/idle_thread/startIntervals.js
+++ b/events/idle_thread/startIntervals.js
@@ -1,6 +1,6 @@
 const { EventBuilder, Events } = require('shardclient');
 const checkIdleThreads = require('../../tasks/idleCheck');
-const checkClosingThreads = require('../../tasks/closeThreads');
+const checkClosingThreads = require('../../tasks/closeCheck');
 module.exports = new EventBuilder()
   .setName('startIntervals')
   .setTrigger(Events.ClientReady)

--- a/events/setupDB.js
+++ b/events/setupDB.js
@@ -1,0 +1,10 @@
+const { setupDatabase } = require('../tasks/schemas');
+const { EventBuilder, Events } = require('shardclient');
+
+module.exports = new EventBuilder()
+  .setName('setupDB')
+  .setTrigger(Events.ClientReady)
+  .setOnce(true)
+  .setCallback(async () => {
+    await setupDatabase();
+  });

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 const { ShardClient, ClientOptions } = require('shardclient');
 const { GatewayIntentBits } = require('discord.js');
+
 const client = new ShardClient(
   new ClientOptions()
     .setGuildCommandsId('1120465621554040942')
     .setDevelopers('439601142528344065')
     .setIntents([GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers])
 );
+
 client.login();

--- a/mariadb.js
+++ b/mariadb.js
@@ -1,0 +1,13 @@
+const mysql = require('mysql2/promise');
+
+const db = mysql.createPool({
+  host: process.env.MYSQL_HOST,
+  user: process.env.MYSQL_USER,
+  password: process.env.MYSQL_PWD,
+  database: process.env.MYSQL_DB,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+});
+
+module.exports = db;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "discord.js": "^14.17.2",
+        "discord.js": "^14.17.3",
+        "mysql2": "^3.12.0",
         "shardclient": "^1.2.4"
       },
       "devDependencies": {
@@ -780,6 +781,14 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -966,15 +975,23 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/discord-api-types": {
       "version": "0.37.114",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.114.tgz",
       "integrity": "sha512-9b9oOpktWSmE6ooToc46wfw151SHC/+idmnZvtwpEzW85BijUspQxj4W2uOmo+nZVTdEyb3fku58k+4rHKpdSQ=="
     },
     "node_modules/discord.js": {
-      "version": "14.17.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.17.2.tgz",
-      "integrity": "sha512-mrH6ziLVtNtId4bV4bsaUt5jE6NUaiHMPqO5VsSw1VVhFnjFi9duD8ctlo90/6cUH+8uyKBkoq9mSJ35SuuZ7Q==",
+      "version": "14.17.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.17.3.tgz",
+      "integrity": "sha512-8/j8udc3CU7dz3Eqch64UaSHoJtUT6IXK4da5ixjbav4NAXJicloWswD/iwn1ImZEMoAV3LscsdO0zhBh6H+0Q==",
       "dependencies": {
         "@discordjs/builders": "^1.10.0",
         "@discordjs/collection": "1.5.3",
@@ -1383,6 +1400,14 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1448,6 +1473,17 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1542,6 +1578,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1678,6 +1719,11 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
+    "node_modules/long": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.0.tgz",
+      "integrity": "sha512-5vvY5yF1zF/kXk+L94FRiTDa1Znom46UjPCH6/XbSvS8zBKMFBHTJk8KDMqJ+2J6QezQFi7k1k8v21ClJYHPaw=="
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1686,6 +1732,20 @@
       "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.1.tgz",
+      "integrity": "sha512-FbAj6lXil6t8z4z3j0E5mfRlPzxkySotzUHwRXjlpRh10vc6AI6WN62ehZj82VG7M20rqogJ0GLwar2Xa05a8Q==",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/magic-bytes.js": {
@@ -1804,6 +1864,44 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mysql2": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.12.0.tgz",
+      "integrity": "sha512-C8fWhVysZoH63tJbX8d10IAoYCyXy4fdRFz2Ihrt9jtPILYynFEKUUzpp1U7qxzDc3tMbotvaBH+sl6bFnGZiw==",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2042,6 +2140,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2050,6 +2153,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/shardclient": {
       "version": "1.2.4",
@@ -2124,6 +2232,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "discord.js": "^14.17.2",
+    "discord.js": "^14.17.3",
+    "mysql2": "^3.12.0",
     "shardclient": "^1.2.4"
   },
   "devDependencies": {

--- a/tasks/closeCheck.js
+++ b/tasks/closeCheck.js
@@ -1,0 +1,23 @@
+const db = require('../mariadb');
+async function checkClosingThreads(client) {
+  const [rows] = await db.execute(`
+    SELECT thread_id, op_id, close_scheduled_time FROM thread_timers
+    WHERE close_scheduled_time IS NOT NULL
+    AND close_scheduled_time < NOW()
+    `);
+
+  for (const { thread_id, op_id } of rows) {
+    try {
+      const thread = await client.channels.fetch(thread_id);
+      if (thread) {
+        await thread.send({ content: `<@${op_id}> Thread has been closed due to inactivity.` });
+        await thread.setArchived(true);
+        console.log(`Thread ${thread_id} closed due to inactivity.`);
+      }
+      await db.execute('DELETE FROM thread_timers WHERE thread_id = ?', [thread_id]);
+    } catch (err) {
+      console.error(`Failed to close thread ${thread_id}:`, err);
+    }
+  }
+}
+module.exports = { checkClosingThreads };

--- a/tasks/closeCheck.js
+++ b/tasks/closeCheck.js
@@ -1,10 +1,15 @@
 const db = require('../mariadb');
+const USER_ID = '439601142528344065';
 async function checkClosingThreads(client) {
-  const [rows] = await db.execute(`
+  const [rows] = await db.execute(
+    `
     SELECT thread_id, op_id, close_scheduled_time FROM thread_timers
     WHERE close_scheduled_time IS NOT NULL
     AND close_scheduled_time < NOW()
-    `);
+    AND op_id = ?
+  `,
+    [USER_ID]
+  );
 
   for (const { thread_id, op_id } of rows) {
     try {

--- a/tasks/closeCheck.js
+++ b/tasks/closeCheck.js
@@ -11,13 +11,16 @@ async function checkClosingThreads(client) {
     [USER_ID]
   );
 
+  console.log(`Found ${rows.length} thread(s) to check for closable status.`);
+
+  if (rows.length === 0) return;
+
   for (const { thread_id, op_id } of rows) {
     try {
       const thread = await client.channels.fetch(thread_id);
       if (thread) {
-        await thread.send({ content: `<@${op_id}> Thread has been closed due to inactivity.` });
+        await thread.send({ content: `<@${op_id}> Your thread has been closed due to inactivity.` });
         await thread.setArchived(true);
-        console.log(`Thread ${thread_id} closed due to inactivity.`);
       }
       await db.execute('DELETE FROM thread_timers WHERE thread_id = ?', [thread_id]);
     } catch (err) {

--- a/tasks/closeCheck.js
+++ b/tasks/closeCheck.js
@@ -1,14 +1,11 @@
 const db = require('../mariadb');
-const USER_ID = '439601142528344065';
 async function checkClosingThreads(client) {
   const [rows] = await db.execute(
     `
     SELECT thread_id, op_id, close_scheduled_time FROM thread_timers
     WHERE close_scheduled_time IS NOT NULL
     AND close_scheduled_time < NOW()
-    AND op_id = ?
-  `,
-    [USER_ID]
+    `
   );
 
   console.log(`Found ${rows.length} thread(s) to check for closable status.`);
@@ -20,6 +17,18 @@ async function checkClosingThreads(client) {
       const thread = await client.channels.fetch(thread_id);
       if (thread) {
         await thread.send({ content: `<@${op_id}> Your thread has been closed due to inactivity.` });
+        const forum = thread.parent;
+        const tags = forum.availableTags;
+        const currentTags = thread.appliedTags;
+        const idleTag = tags.find(tag => tag.name.toLowerCase() === 'idle');
+        if (!idleTag) {
+          console.log('No idle tag found, does it exist?');
+        } else if (currentTags.includes(idleTag.id)) {
+          console.log('Thread already has idle tag, skipping');
+        } else {
+          const newTags = [idleTag.id];
+          await thread.setAppliedTags(newTags);
+        }
         await thread.setArchived(true);
       }
       await db.execute('DELETE FROM thread_timers WHERE thread_id = ?', [thread_id]);

--- a/tasks/idleCheck.js
+++ b/tasks/idleCheck.js
@@ -1,10 +1,15 @@
 const db = require('../mariadb');
+const USER_ID = '439601142528344065';
 async function checkIdleThreads(client) {
-  const [rows] = await db.execute(`
+  const [rows] = await db.execute(
+    `
     SELECT thread_id, op_id, reminder_sent_time FROM thread_timers
     WHERE reminder_sent = FALSE
     AND last_posted < NOW() - INTERVAL 48 HOUR
-    `);
+    AND op_id = ?
+  `,
+    [USER_ID]
+  );
 
   for (const { thread_id, op_id } of rows) {
     try {

--- a/tasks/idleCheck.js
+++ b/tasks/idleCheck.js
@@ -3,7 +3,7 @@ const USER_ID = '439601142528344065';
 async function checkIdleThreads(client) {
   const [rows] = await db.execute(
     `
-    SELECT thread_id, op_id, reminder_sent_time FROM thread_timers
+    SELECT thread_id, op_id, reminder_sent FROM thread_timers
     WHERE reminder_sent = FALSE
     AND last_posted < NOW() - INTERVAL 2 MINUTE
     AND op_id = ?

--- a/tasks/idleCheck.js
+++ b/tasks/idleCheck.js
@@ -5,7 +5,7 @@ async function checkIdleThreads(client) {
     `
     SELECT thread_id, op_id, reminder_sent_time FROM thread_timers
     WHERE reminder_sent = FALSE
-    AND last_posted < NOW() - INTERVAL 48 HOUR
+    AND last_posted < NOW() - INTERVAL 2 MINUTE
     AND op_id = ?
   `,
     [USER_ID]
@@ -30,13 +30,13 @@ async function checkIdleThreads(client) {
           continue;
         }
         await thread.send({
-          content: `<@${op_id}> Your thread has been idle for over 48 hours. 
-            <tree_end:951969115264913528> If this issue is not resolved, please reply within 24hrs to prevent this thread from closing.`,
+          content: `<@${op_id}> Your thread has been idle for over 2 minutes. 
+            <tree_end:951969115264913528> If this issue is not resolved, please reply within 3 minutes to prevent this thread from closing.`,
         });
         await db.execute(
           `
           UPDATE thread_timers 
-          SET reminder_sent = TRUE, close_scheduled_time = NOW() + INTERVAL 24 HOUR 
+          SET reminder_sent = TRUE, close_scheduled_time = NOW() + INTERVAL 3 MINUTE 
           WHERE thread_id = ?`,
           [thread_id]
         );

--- a/tasks/idleCheck.js
+++ b/tasks/idleCheck.js
@@ -5,43 +5,54 @@ async function checkIdleThreads(client) {
     `
     SELECT thread_id, op_id, reminder_sent FROM thread_timers
     WHERE reminder_sent = FALSE
-    AND last_posted < NOW() - INTERVAL 2 MINUTE
+    AND last_posted < NOW() - INTERVAL 48 HOUR
     AND op_id = ?
   `,
     [USER_ID]
   );
 
+  console.log(`Found ${rows.length} thread(s) to check for idle status.`);
+
+  if (rows.length === 0) return;
+
   for (const { thread_id, op_id } of rows) {
     try {
       const thread = await client.channels.fetch(thread_id);
-      if (thread) {
-        const lastMessage = await thread.messages.fetch({ limit: 1 });
-        const lastMessageAuthor = lastMessage.first()?.author.id;
+      if (!thread) {
+        console.log(`Thread ${thread_id} not found. Deleting from database.`);
+        await db.execute(
+          `
+          DELETE FROM thread_timers WHERE thread_id = ?
+          `,
+          [thread_id]
+        );
+        continue;
+      }
 
-        if (lastMessageAuthor === op_id) {
-          await db.execute(
-            `
-            UPDATE thread_timers 
-            SET last_posted = NOW(), close_scheduled_time = NULL 
-            WHERE thread_id = ?`,
-            [thread_id]
-          );
-          console.log(`Reminder skipped, last message was posted by OP in thread ${thread_id}`);
-          continue;
-        }
-        await thread.send({
-          content: `<@${op_id}> Your thread has been idle for over 2 minutes. 
-            <tree_end:951969115264913528> If this issue is not resolved, please reply within 3 minutes to prevent this thread from closing.`,
-        });
+      const lastMessage = await thread.messages.fetch({ limit: 1 });
+      const lastMessageAuthor = lastMessage.first()?.author.id;
+      if (lastMessageAuthor === op_id) {
         await db.execute(
           `
           UPDATE thread_timers 
-          SET reminder_sent = TRUE, close_scheduled_time = NOW() + INTERVAL 3 MINUTE 
+          SET last_posted = NOW(), close_scheduled_time = NULL 
           WHERE thread_id = ?`,
           [thread_id]
         );
+        continue;
       }
-      console.log(`Sent reminder to ${op_id} in thread ${thread_id}`);
+
+      await thread.send({
+        content: `<@${op_id}> Your thread has been idle for over 48 hours. 
+            <tree_end:951969115264913528> If this issue is not resolved, please reply within 24hrs to prevent this thread from closing.`,
+      });
+      await db.execute(
+        `
+          UPDATE thread_timers 
+          SET reminder_sent = TRUE, close_scheduled_time = NOW() + INTERVAL 24 HOUR 
+          WHERE thread_id = ?`,
+        [thread_id]
+      );
     } catch (err) {
       console.error(`Failed to send message in thread ${thread_id}:`, err);
     }

--- a/tasks/idleCheck.js
+++ b/tasks/idleCheck.js
@@ -1,0 +1,46 @@
+const db = require('../mariadb');
+async function checkIdleThreads(client) {
+  const [rows] = await db.execute(`
+    SELECT thread_id, op_id, reminder_sent_time FROM thread_timers
+    WHERE reminder_sent = FALSE
+    AND last_posted < NOW() - INTERVAL 48 HOUR
+    `);
+
+  for (const { thread_id, op_id } of rows) {
+    try {
+      const thread = await client.channels.fetch(thread_id);
+      if (thread) {
+        const lastMessage = await thread.messages.fetch({ limit: 1 });
+        const lastMessageAuthor = lastMessage.first()?.author.id;
+
+        if (lastMessageAuthor === op_id) {
+          await db.execute(
+            `
+            UPDATE thread_timers 
+            SET last_posted = NOW(), close_scheduled_time = NULL 
+            WHERE thread_id = ?`,
+            [thread_id]
+          );
+          console.log(`Reminder skipped, last message was posted by OP in thread ${thread_id}`);
+          continue;
+        }
+        await thread.send({
+          content: `<@${op_id}> Your thread has been idle for over 48 hours. 
+            <tree_end:951969115264913528> If this issue is not resolved, please reply within 24hrs to prevent this thread from closing.`,
+        });
+        await db.execute(
+          `
+          UPDATE thread_timers 
+          SET reminder_sent = TRUE, close_scheduled_time = NOW() + INTERVAL 24 HOUR 
+          WHERE thread_id = ?`,
+          [thread_id]
+        );
+      }
+      console.log(`Sent reminder to ${op_id} in thread ${thread_id}`);
+    } catch (err) {
+      console.error(`Failed to send message in thread ${thread_id}:`, err);
+    }
+  }
+}
+
+module.exports = { checkIdleThreads };

--- a/tasks/schemas.js
+++ b/tasks/schemas.js
@@ -1,0 +1,12 @@
+const db = require('../mariadb');
+
+async function setupDatabase() {
+  await db.execute(`CREATE TABLE IF NOT EXISTS thread_timers (
+    thread_id VARCHAR(50) PRIMARY KEY,
+    op_id VARCHAR(50) NOT NULL,
+    last_posted TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    reminder_sent BOOLEAN DEFAULT FALSE,
+    close_scheduled_time TIMESTAMP DEFAULT NULL)`);
+}
+
+module.exports = { setupDatabase };


### PR DESCRIPTION
- Updated Discord.js
- Added automation flow for thread timer/closing for idles.
    - Thread creation/message initiates database document
    - Thread creator idle for 48hrs, send idle message
    - Thread creator idle for 24hrs, close thread and mark as idle
    - Waiting tag can be applied to override thread automation
  
Bug Fixes
- /solved can only be used inside support category thread channel types
- /solved will still archive the thread if the solved tag is already applied